### PR TITLE
GRASP-11975 Migrate to C++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.12)
+set(CMAKE_CXX_STANDARD 20)
 
 # Read version from the package.xml file.
 file(READ ${CMAKE_CURRENT_SOURCE_DIR}/package.xml package_xml_str)


### PR DESCRIPTION
Migrate the library to use C++20

It was tested on my local machine:
![Screenshot from 2022-05-12 11-03-48](https://user-images.githubusercontent.com/3832914/168034766-14738e9b-472f-49eb-a444-f5cf7419a4f6.png)
